### PR TITLE
Add landing page (site/index.html)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,213 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Awesome Agentic Engineering</title>
+<meta name="description" content="A curated map of the best resources for learning agentic engineering and the AI-native SDLC. Operator-maintained by Fatih Koc.">
+<style>
+  :root {
+    --bg: #f6f7f7;
+    --surface: #ffffff;
+    --text: #14181b;
+    --muted: #59636b;
+    --line: #e3e7ea;
+    --accent: #0d8f80;
+    --accent-ink: #0b5f56;
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --maxw: 900px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0b0e10;
+      --surface: #14181b;
+      --text: #e8eef1;
+      --muted: #97a4ad;
+      --line: #222a2f;
+      --accent: #2fd4c1;
+      --accent-ink: #86ecdf;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+  a { color: inherit; }
+
+  /* Eyebrow / label system (monospace) */
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent-ink);
+    margin: 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .eyebrow::before {
+    content: "";
+    width: 26px;
+    height: 1px;
+    background: var(--accent);
+    display: inline-block;
+  }
+
+  /* Hero */
+  header.hero { padding: clamp(64px, 12vw, 128px) 0 clamp(40px, 7vw, 72px); }
+  h1 {
+    font-size: clamp(40px, 8vw, 76px);
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    font-weight: 800;
+    margin: 0 0 22px;
+    max-width: 15ch;
+  }
+  h1 .mark { color: var(--accent); }
+  .lede {
+    font-size: clamp(18px, 2.4vw, 22px);
+    color: var(--text);
+    max-width: 42ch;
+    margin: 0 0 16px;
+  }
+  .sub {
+    font-size: 16px;
+    color: var(--muted);
+    max-width: 56ch;
+    margin: 0 0 34px;
+  }
+
+  /* Buttons */
+  .actions { display: flex; flex-wrap: wrap; gap: 12px; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    font-family: var(--mono);
+    font-size: 14px;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    padding: 12px 18px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    transition: transform .12s ease, border-color .12s ease, background .12s ease;
+  }
+  .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+  .btn.primary { background: var(--accent); color: #04120f; border-color: var(--accent); font-weight: 600; }
+  .btn.primary:hover { transform: translateY(-1px); }
+  .btn.ghost { background: transparent; color: var(--text); }
+  .btn.ghost:hover { border-color: var(--accent); color: var(--accent-ink); }
+
+  /* Section framing */
+  section { padding: clamp(40px, 7vw, 72px) 0; border-top: 1px solid var(--line); }
+  .section-head { margin-bottom: 30px; }
+  .section-head h2 { font-size: clamp(22px, 3vw, 28px); letter-spacing: -0.01em; margin: 0; font-weight: 700; }
+  .section-head p { color: var(--muted); margin: 8px 0 0; max-width: 54ch; }
+
+  /* Category manifest (signature element) */
+  ol.manifest { list-style: none; margin: 0; padding: 0; }
+  ol.manifest li { border-top: 1px solid var(--line); }
+  ol.manifest li:last-child { border-bottom: 1px solid var(--line); }
+  ol.manifest a {
+    display: grid;
+    grid-template-columns: 3.2rem 1fr auto;
+    align-items: baseline;
+    gap: 18px;
+    padding: 16px 6px;
+    text-decoration: none;
+    transition: background .12s ease, padding .12s ease;
+  }
+  ol.manifest a:hover { background: color-mix(in srgb, var(--accent) 8%, transparent); padding-left: 14px; }
+  ol.manifest a:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .idx { font-family: var(--mono); font-size: 13px; color: var(--accent-ink); }
+  .cat { font-size: clamp(17px, 2.2vw, 20px); font-weight: 600; letter-spacing: -0.01em; }
+  .go { font-family: var(--mono); font-size: 13px; color: var(--muted); }
+  ol.manifest a:hover .go { color: var(--accent-ink); }
+
+  /* Maintained note */
+  .note p { margin: 0; max-width: 60ch; color: var(--text); }
+  .note p + p { margin-top: 14px; color: var(--muted); }
+
+  /* Footer */
+  footer { border-top: 1px solid var(--line); padding: 34px 0 56px; }
+  .footrow { display: flex; flex-wrap: wrap; gap: 8px 22px; align-items: center; justify-content: space-between; }
+  .footrow p { margin: 0; color: var(--muted); font-size: 14px; }
+  .footrow a { color: var(--accent-ink); text-decoration: none; }
+  .footrow a:hover { text-decoration: underline; }
+  .footlinks { font-family: var(--mono); font-size: 13px; display: flex; gap: 18px; flex-wrap: wrap; }
+
+  @media (max-width: 520px) {
+    ol.manifest a { grid-template-columns: 2.6rem 1fr; }
+    ol.manifest .go { display: none; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="hero">
+      <p class="eyebrow">Operator-maintained, open to contributions</p>
+      <h1>Awesome <span class="mark">Agentic</span> Engineering</h1>
+      <p class="lede">A curated map of the best resources for learning agentic engineering and the AI-native SDLC.</p>
+      <p class="sub">Agentic engineering is building and shipping software by directing AI coding agents across the lifecycle: you set the goal, delegate, and verify what they produce. This list collects the highest-signal resources for learning it, with a bias toward what holds up in real engineering practice rather than hype.</p>
+      <div class="actions">
+        <a class="btn primary" href="https://github.com/fatihkc/awesome-agentic-engineering">Browse the list on GitHub</a>
+        <a class="btn ghost" href="https://github.com/fatihkc/awesome-agentic-engineering/blob/main/CONTRIBUTING.md">Contribute a resource</a>
+      </div>
+    </header>
+
+    <section aria-labelledby="inside">
+      <div class="section-head">
+        <p class="eyebrow">What is inside</p>
+        <h2 id="inside">Eleven sections, from first principles to production</h2>
+        <p>Each links straight into the list. Start at the top if you are new, or jump to what you need.</p>
+      </div>
+      <ol class="manifest">
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#start-here"><span class="idx">01</span><span class="cat">Start here</span><span class="go">read first</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#foundations"><span class="idx">02</span><span class="cat">Foundations</span><span class="go">the seminal work</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#coding-agents-and-tools"><span class="idx">03</span><span class="cat">Coding agents and tools</span><span class="go">the harnesses</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#books"><span class="idx">04</span><span class="cat">Books</span><span class="go">go deep</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#courses"><span class="idx">05</span><span class="cat">Courses</span><span class="go">hands-on</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#podcasts"><span class="idx">06</span><span class="cat">Podcasts</span><span class="go">listen</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#blogs-and-newsletters"><span class="idx">07</span><span class="cat">Blogs and newsletters</span><span class="go">stay current</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#essays-and-writing"><span class="idx">08</span><span class="cat">Essays and writing</span><span class="go">the arguments</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#videos-and-talks"><span class="idx">09</span><span class="cat">Videos and talks</span><span class="go">watch</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#case-studies-and-in-practice"><span class="idx">10</span><span class="cat">Case studies and in practice</span><span class="go">from production</span></a></li>
+        <li><a href="https://github.com/fatihkc/awesome-agentic-engineering#communities"><span class="idx">11</span><span class="cat">Communities</span><span class="go">find your people</span></a></li>
+      </ol>
+    </section>
+
+    <section class="note" aria-labelledby="maintained">
+      <div class="section-head">
+        <p class="eyebrow">How it stays honest</p>
+        <h2 id="maintained">Curated by an operator, not a crawler</h2>
+      </div>
+      <p>Every entry is a real, substantive resource from an identifiable author, checked by hand. The bar is what survives real engineering practice, so a resource earns its place by being useful, not by being new.</p>
+      <p>Suggestions are welcome. Open a pull request with the resource, the section, and one line on why it belongs.</p>
+    </section>
+  </div>
+
+  <footer>
+    <div class="wrap footrow">
+      <p>Maintained by <a href="https://fatihkoc.net">Fatih Koc</a>.</p>
+      <nav class="footlinks">
+        <a href="https://github.com/fatihkc/awesome-agentic-engineering">Repository</a>
+        <a href="https://github.com/fatihkc/awesome-agentic-engineering/blob/main/CONTRIBUTING.md">Contribute</a>
+        <a href="https://fatihkoc.net">fatihkoc.net</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What

A minimal, self-contained landing page for the list at `site/index.html`: one screen with the framing, the eleven sections as an index that links into the README, and a prominent path to browse and contribute. Theme-aware (light and dark), no external requests (inline CSS, system fonts, no images or CDNs).

Intended as the soft-announce front door, not the Show HN launch page.

## Deploy

Point Cloudflare Pages at this repo with the build output directory set to `site/`, then map `awesomeagenticengineering.com` to it (replacing the current 301 to the repo). Or drag-drop `site/index.html` into a Pages direct upload.

## Provenance

Drafted by the `wiki-autodev-execute` skill (Phase B of the wiki-autodev routine), run by hand as its first end-to-end smoke test, from the `awesome-landing-page` task in the hub's queue. Human-fronted: this is a draft PR for review, never auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)