### PR TITLE
Make the list lean: per-section caps, cull, add-or-swap curator

### DIFF
--- a/.claude/skills/weekly-curator/SKILL.md
+++ b/.claude/skills/weekly-curator/SKILL.md
@@ -5,9 +5,11 @@ description: Weekly maintenance for the awesome-agentic-engineering list. Drafts
 
 # Weekly curator
 
-Keep the awesome-agentic-engineering list fresh and high-signal. This skill DRAFTS a pull request; a human
-reviews and merges it. Never merge, never push to main. That human gate is the anti-slop guardrail, and it
-is the whole point: adding slop damages the maintainer's reputation, which is what the list exists to build.
+Keep the awesome-agentic-engineering list fresh, high-signal, and LEAN. This list is bounded: each section
+has a maximum in `.github/section-caps.txt`, and a full section only gains an entry by displacing a weaker
+one. This skill DRAFTS a pull request; a human reviews and merges it. Never merge, never push to main. That
+human gate is the anti-slop guardrail, and it is the whole point: adding slop damages the maintainer's
+reputation, which is what the list exists to build.
 
 ## Scope
 Agentic engineering means building and shipping software by directing AI coding agents across the SDLC:
@@ -15,33 +17,54 @@ coding agents and harnesses, loop and context engineering, spec-driven developme
 production case studies. Keep resources that are about engineering software WITH agents. Out of scope:
 building agent applications or products (agent frameworks, RAG chatbots) and general LLM or ML research.
 
+## The cap (what "lean" means here)
+Every section has an entry cap in `.github/section-caps.txt`. Read that file each run; never hardcode the
+numbers. CI (`.github/check-caps.py`) fails any PR that pushes a section over its cap, so a bare add into a
+full section is not an option. When a section is full, you displace, you do not append.
+
 ## Steps
-1. Read `README.md` and `CONTRIBUTING.md` for the current scope, categories, format, and quality bar.
+1. Read `README.md`, `CONTRIBUTING.md`, and `.github/section-caps.txt` for the current scope, categories,
+   format, quality bar, and caps.
 2. Maintain existing entries:
    - Check every link in `README.md` still resolves (follow redirects, use a browser user agent since some
      hosts block bots). Flag anything that 404s, errors, or is permanently dead.
    - Flag entries that have gone stale or out of scope (abandoned or archived tools, superseded resources,
      moved pages), and note obvious successor URLs.
+   - A dead, broken, or clearly-superseded entry that you remove simply frees a slot. Removal is not a swap.
 3. Scan for new resources published or updated in roughly the last one to two weeks, plus anything notable
    that is missing. Look at GitHub Trending and new releases for coding agents and harnesses, Hacker News
    and Show HN, the AI Engineer and Latent Space ecosystem, and practitioner and lab engineering blogs. For
    each candidate capture the title, author or source, URL, a one-line neutral description, and the target
-   category. Verify each URL resolves.
+   section. Verify each URL resolves.
 4. Apply the quality bar: real, substantive, in-scope resources from an identifiable author or source; no
    dead links; no duplicates; no marketing or SEO-spam pages; no em-dashes or en-dashes; no emojis; neutral
    one-line descriptions matching the format `- [Title](url) - description.`. When in doubt, leave it out.
-   Aim for a small, high-signal batch (about three to eight additions), never volume.
-5. Create a branch `curate/YYYY-MM-DD`, apply additions to the correct sections keeping formatting and
-   ordering consistent, commit, push the branch, and open a pull request titled
-   `curate: weekly review YYYY-MM-DD`. Structure the PR body in three parts:
-   - Additions, each with a one-line rationale.
+5. Place each surviving candidate against its section's cap:
+   - Section is UNDER cap: add it (a bare add), keeping ordering consistent.
+   - Section is AT cap: draft a SWAP. Add the candidate and remove the weakest incumbent in that same
+     section, chosen against the quality bar and the "what's real vs theater" spine (least adopted or cited,
+     most superseded, most marketing-adjacent, least evergreen; Foundations entries are seminal and are not
+     displaced). At most ONE swap per section per run. If several candidates beat incumbents in one section,
+     take the single strongest and name the runner-up in the PR body without adding it.
+   - Every swap needs a one-line head-to-head rationale: new beats old because X; old is superseded by or
+     weaker than Y.
+   - If a swap removes the second copy of a URL that was in `.github/allowed-duplicate-links.txt`, drop that
+     now-stale allowlist line too.
+6. Create a branch `curate/YYYY-MM-DD`, apply the changes keeping formatting and ordering consistent,
+   commit, push the branch, and open a pull request titled `curate: weekly review YYYY-MM-DD`. Structure the
+   PR body in four parts:
+   - Additions (to under-cap sections), each with a one-line rationale.
+   - Swaps, each as `+ add / - cut` with the head-to-head rationale.
    - Dead or broken links found, with entry and status.
    - Stale or out-of-scope entries to review, with entry and reason.
-6. Do NOT merge and do NOT push to main. If nothing clears the bar and there are no maintenance findings,
-   open no pull request. If there are only maintenance findings, open a pull request with just those.
+7. Before opening the PR, run `python3 .github/check-caps.py README.md .github/section-caps.txt` and confirm
+   it passes. Do NOT merge and do NOT push to main. If nothing clears the bar and there are no maintenance
+   findings, open no pull request. If there are only maintenance findings, open a pull request with just
+   those.
 
 ## Rules
 - You draft, the human ships. Never merge, never push to main.
+- The list is bounded. A full section is displaced, never appended to. One swap per section per run.
 - Small and high-signal beats large and noisy.
 - No em-dashes or en-dashes (use commas or parentheses); no emojis.
 - When in doubt, leave it out.

--- a/.github/allowed-duplicate-links.txt
+++ b/.github/allowed-duplicate-links.txt
@@ -1,8 +1,4 @@
 https://www.youtube.com/watch?v=LCEmiRjPEtQ
 https://www.anthropic.com/engineering/building-effective-agents
-https://www.anthropic.com/engineering/claude-code-best-practices
-https://github.com/humanlayer/12-factor-agents
-https://simonwillison.net/2025/Sep/30/designing-agentic-loops/
-https://www.youtube.com/watch?v=rmvDxxNubIg
 https://www.deeplearning.ai/courses/spec-driven-development-with-coding-agents
 https://claude.com/product/claude-code

--- a/.github/check-caps.py
+++ b/.github/check-caps.py
@@ -1,0 +1,51 @@
+"""Fail if any capped section in README.md exceeds its entry cap.
+
+Caps live in .github/section-caps.txt, one `Section heading = N` per line
+(blank lines and `#` comments ignored). An entry is a top-level list item
+that starts a link: a line beginning with `- [`. Sections not named in the
+caps file (Contents, Contributing, How this list is maintained) are ignored.
+"""
+import re
+import sys
+from pathlib import Path
+
+readme = Path(sys.argv[1]).read_text()
+caps_text = Path(sys.argv[2]).read_text()
+
+caps = {}
+for line in caps_text.splitlines():
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    name, sep, value = line.partition("=")
+    if not sep:
+        continue
+    caps[name.strip()] = int(value.strip())
+
+counts = {}
+current = None
+for line in readme.splitlines():
+    heading = re.match(r"##\s+(.*)", line)
+    if heading:
+        current = heading.group(1).strip()
+        counts.setdefault(current, 0)
+        continue
+    if current is not None and line.startswith("- ["):
+        counts[current] += 1
+
+errors = []
+for section, cap in caps.items():
+    count = counts.get(section)
+    if count is None:
+        errors.append(f"{section!r}: named in caps file but no such section in README")
+    elif count > cap:
+        errors.append(f"{section!r}: {count} entries, cap is {cap}")
+
+if errors:
+    print("Section cap check failed:")
+    print("\n".join(errors))
+    sys.exit(1)
+
+print("Section caps OK:")
+for section, cap in caps.items():
+    print(f"  {section}: {counts.get(section, 0)}/{cap}")

--- a/.github/section-caps.txt
+++ b/.github/section-caps.txt
@@ -1,0 +1,14 @@
+# Per-section entry caps for the bounded best-N list.
+# One `Section heading = N` per capped section. Headings must match README.md `##` headings exactly.
+# Sections not listed here (Contents, Contributing, How this list is maintained) are uncapped.
+Start here = 7
+Foundations = 5
+Coding agents and tools = 8
+Books = 6
+Courses = 5
+Podcasts = 5
+Blogs and newsletters = 6
+Essays and writing = 6
+Videos and talks = 5
+Case studies and in practice = 6
+Communities = 5

--- a/.github/section-caps.txt
+++ b/.github/section-caps.txt
@@ -10,5 +10,5 @@ Podcasts = 5
 Blogs and newsletters = 6
 Essays and writing = 6
 Videos and talks = 5
-Case studies and in practice = 6
+Case studies and in practice = 7
 Communities = 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,11 @@ jobs:
             --accept '200..=206,403,429'
             README.md CONTRIBUTING.md
           fail: true
+
+  caps:
+    name: section caps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce per-section entry caps
+        run: python3 .github/check-caps.py README.md .github/section-caps.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,15 @@ development lifecycle: coding agents and harnesses, loop and context engineering
 evals, review and verification, and production case studies. Resources about ENGINEERING SOFTWARE WITH
 AGENTS belong here.
 
+## This list is bounded
+This is a best-N list, not a comprehensive one. Each section has a maximum (see
+[`.github/section-caps.txt`](.github/section-caps.txt)), enforced in CI. A full section grows only by
+displacement, so a pull request that adds to a section already at its cap will show a red cap-check until an
+entry is removed. You are welcome to suggest which weaker entry yours should replace and why, but you do not
+have to: the maintainer makes the final call on what leaves. When a section is full, the bar is not "is this
+good" but "is this better than the weakest entry already here", and a pull request that does not clear that
+bar may be declined.
+
 ## What belongs here
 - Real, substantive resources across any type: books, courses, podcasts, blogs, essays, talks, tools,
   communities, and case studies.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ A short on-ramp: read the framing, learn to direct one agent well, then see it r
 - [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices) - How to actually direct a coding agent: workflows, context files, permissions, patterns.
 - [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) - Twelve principles for reliable, production-grade LLM software.
 - [Designing agentic loops](https://simonwillison.net/2025/Sep/30/designing-agentic-loops/) - Loop engineering: goals, tools, and safety constraints so an agent can iterate toward a solution.
-- [No Vibes Allowed](https://www.youtube.com/watch?v=rmvDxxNubIg) - The Research, Plan, Implement workflow for getting agents to work in complex codebases.
 - [Spec-Driven Development with Coding Agents](https://www.deeplearning.ai/courses/spec-driven-development-with-coding-agents) - A hands-on course on the plan, implement, verify workflow with agents.
 - [Claude Code](https://claude.com/product/claude-code) - A capable coding agent to start practicing with today.
 
@@ -49,15 +48,9 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [Cursor](https://cursor.com/) - AI code editor and agent for building software across desktop, CLI, and mobile. By Anysphere.
 - [Aider](https://github.com/Aider-AI/aider) - Open-source terminal pair-programming agent that edits code in a local Git repository using an LLM of choice.
 - [Cline](https://github.com/cline/cline) - Open-source autonomous coding agent available as an IDE extension, CLI, and SDK.
-- [Sourcegraph Amp](https://ampcode.com/) - Agentic coding tool with terminal, IDE, and web interfaces plus sub-agents for code review and library research.
-- [Factory (Droids)](https://factory.ai/) - Platform of role-specialized coding agents (Droids) that automate tasks across the software development lifecycle.
 - [Devin](https://devin.ai/) - Autonomous AI software engineer for long-horizon tasks like migrations, bug fixes, and PRs. By Cognition.
-- [Google Jules](https://jules.google/) - Autonomous coding agent that handles bug fixes, dependency updates, and testing asynchronously against a repository.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) - Open-source, self-hostable platform for running coding agents and automations.
 - [Model Context Protocol](https://modelcontextprotocol.io/) - Open standard for connecting coding agents to external tools, data, and workflows. By Anthropic.
-- [Terminal-Bench](https://www.tbench.ai/) - Benchmark and Harbor harness measuring agents on realistic command-line tasks, with adapters for Claude Code and Codex CLI. By Stanford and the Laude Institute.
-- [CodeRabbit](https://www.coderabbit.ai/) - AI code review tool that reviews pull requests and works in the IDE and CLI.
-- [Spec Kit](https://github.com/github/spec-kit) - Open-source toolkit of slash commands and templates for spec-driven development, compatible with Claude Code and 30-plus other coding agents. By GitHub.
 
 ## Books
 - [AI-Assisted Programming](https://www.amazon.com/AI-Assisted-Programming-Planning-Testing-Deployment/dp/1098164563) - Using AI dev tools across the lifecycle: requirements, planning, design, coding, debugging, testing, deployment. By Tom Taulli (O'Reilly).
@@ -66,7 +59,6 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [Vibe Engineering](https://www.manning.com/books/vibe-engineering) - An end-to-end process for AI-augmented development: agentic coding, validating AI-generated code, refactoring, and team collaboration. By Tomasz Lelek and Artur Skowronski (Manning).
 - [AI-Assisted Coding: The Practical Guide](https://www.sap-press.com/ai-assisted-coding_6058/) - AI pair programming with tools like Copilot, Ollama, and Aider, covering prompts, generation, testing, and local models. By Kofler, Oggl, and Springer (Rheinwerk).
 - [Agentic Coding with Claude Code](https://github.com/PacktPublishing/Agentic-Coding-with-Claude-Code) - Directing Claude Code as a development platform: context engineering, memory files, slash commands, hooks, MCP, and subagents. By Eden Marco (Packt).
-- [Generative AI for Software Development](https://books.google.com/books/about/Generative_AI_for_Software_Development.html?id=QrZxEQAAQBAJ) - Evaluating AI tools and workflows across code generation, review, testing, and docs, with case studies. By Sergio Pereira (O'Reilly).
 
 ## Courses
 - [Claude Code: A Highly Agentic Coding Assistant](https://www.deeplearning.ai/courses/claude-code-a-highly-agentic-coding-assistant) - Free short course on Claude Code best practices: codebase exploration, planning, testing, refactoring, and MCP. (DeepLearning.AI and Anthropic)
@@ -74,39 +66,29 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action) - Free course on integrating Claude Code into a workflow: tools, context, plan mode, custom commands, hooks, SDK, and MCP. (Anthropic Academy)
 - [Claude Code: Software Engineering with Generative AI Agents](https://www.coursera.org/learn/claude-code) - Orchestrating Claude Code across Git worktrees with CLAUDE.md context, reusable commands, subagents, and QA patterns. By Jules White (Vanderbilt, Coursera).
 - [Learn Cursor](https://cursor.com/learn) - Cursor's official tutorials on AI foundations, coding with the agent, and reviewing and testing agent-generated code.
-- [Anthropic Academy](https://anthropic.skilljar.com/) - Free self-paced catalog including Claude Code 101, Introduction to Subagents, and Introduction to MCP.
 
 ## Podcasts
 - [The AI Native Dev](https://tessl.io/podcast/) - AI-native software development: coding agents, spec- and context-driven development, and running the SDLC with agents. Hosted by Guy Podjarny and Simon Maple.
 - [Latent Space](https://www.latent.space/podcast) - Technical interviews for AI engineers with recurring deep dives on coding agents and harnesses (Claude Code, Cursor, Codex, Devin). Hosted by swyx and Alessio Fanelli.
 - [The Pragmatic Engineer Podcast](https://newsletter.pragmaticengineer.com/podcast/archive) - Engineering interviews including Boris Cherny on building Claude Code and Kent Beck on TDD with agents. Hosted by Gergely Orosz.
-- [The Agentic Review Podcast](https://www.qodo.ai/podcasts/) - Code quality, review, trust, and governance when shipping software with AI coding agents. By Qodo.
 - [AI & I](https://podcasts.apple.com/us/podcast/ai-i/id1719789201) - Builders walking through their workflows, including shipping features with Claude Code and other agentic tools. Hosted by Dan Shipper (Every).
 - [Agentic Coding Today](https://podcasts.apple.com/us/podcast/agentic-coding-today/id1878647688) - Short-form show tracking coding agents like Claude Code and Codex: workflows, patterns, and what works versus hype.
 
 ## Blogs and newsletters
 - [Simon Willison's Weblog](https://simonwillison.net/) - Near-daily hands-on writing on coding agents (Claude Code, Codex), model releases, and agentic engineering patterns.
-- [Armin Ronacher (lucumr)](https://lucumr.pocoo.org/) - Recurring essays on coding-agent loops, harnesses, and tooling for LLM-driven development. Creator of Flask.
 - [Peter Steinberger](https://steipete.me/) - Field notes on agentic engineering workflows, Claude Code setups, and shipping code by directing agents.
 - [The Pragmatic Engineer](https://newsletter.pragmaticengineer.com/) - Engineering newsletter with recurring coverage of AI coding tools, adoption data, and how teams ship with agents. By Gergely Orosz.
-- [Factory Blog](https://factory.ai/news) - Company engineering blog on Droid coding agents, Terminal-Bench results, and the agent-native SDLC.
-- [Cognition Blog](https://cognition.com/blog) - Engineering blog behind Devin on autonomous coding agents, code review, and enterprise migrations.
 - [Anthropic Engineering Blog](https://www.anthropic.com/engineering) - Posts on Claude Code, harness design for long-running development, parallel agents, and coding-agent evals.
 - [Exploring Generative AI](https://martinfowler.com/articles/exploring-gen-ai.html) - Ongoing Thoughtworks memo series on harness engineering, context engineering, and spec-driven development. By Birgitta Boeckeler and colleagues.
 - [Geoffrey Huntley](https://ghuntley.com/) - Writing on building and running coding agents, loop-based methods (the ralph loop), and software-factory workflows.
 
 ## Essays and writing
-- [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices) - Workflows, CLAUDE.md files, permissions, and agentic patterns for getting good results from a coding agent. By Anthropic.
-- [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) - Twelve principles (own your prompts, context, and control flow) for engineering production-grade LLM software. By Dex Horthy.
-- [Designing agentic loops](https://simonwillison.net/2025/Sep/30/designing-agentic-loops/) - Defining goals, tools, and safety constraints so a coding agent can iterate toward a solution. By Simon Willison.
 - [Agentic Coding Recommendations](https://lucumr.pocoo.org/2025/6/12/agentic-coding/) - Field-tested advice on language choice, tool speed, logging, and codebase structure that make coding agents effective. By Armin Ronacher.
 - [Revenge of the Junior Developer](https://sourcegraph.com/blog/revenge-of-the-junior-developer) - Six overlapping waves from completions to autonomous agents, agent clusters, and agent fleets. By Steve Yegge.
-- [Factory 2.0: From Coding Agents to Software Factories](https://factory.ai/news/software-factory) - The software-factory vision of an interconnected, agent-native system spanning bug report to deploy. By Matan Grinberg and Eno Reyes.
 - [My LLM Codegen Workflow](https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/) - A spec, then plan, then execute workflow for building software with LLMs on greenfield and existing code. By Harper Reed.
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - The Ralph technique: running a coding agent in a bash loop that repeatedly feeds one prompt, with progress persisted to files and git. By Geoffrey Huntley.
 - [Advanced Context Engineering for Coding Agents](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents/blob/main/ace-fca.md) - Intentional compaction and a research, plan, implement workflow for coding agents in large legacy codebases. By Dex Horthy.
 - [Not All AI-Assisted Programming Is Vibe Coding](https://simonwillison.net/2025/Mar/19/vibe-coding/) - Distinguishes unreviewed vibe coding from professional AI-assisted engineering where you review, test, and can explain the code. By Simon Willison.
-- [Better Models: Worse Tools](https://lucumr.pocoo.org/2026/7/4/better-models-worse-tools/) - A field report on newer Claude models regressing on structured tool-call arguments, and what that implies about the fragility of coding agent harnesses. By Armin Ronacher.
 
 ## Videos and talks
 - [Claude Code and the Evolution of Agentic Coding](https://www.youtube.com/watch?v=Lue8K2jqfKk) - How coding agents differ from autocomplete and how agentic coding workflows are evolving. By Boris Cherny (Anthropic).
@@ -114,25 +96,18 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [Engineering Practices That Make Coding Agents Work](https://www.youtube.com/watch?v=owmJyKVu5f8) - Concrete practices, testing, and verification patterns for reliable results from Claude Code and Codex. By Simon Willison.
 - [The New Code: Specifications as the Fundamental Unit of AI-Era Programming](https://www.youtube.com/watch?v=8rABwKRsec4) - Argues written specs, not code, become the primary artifact when directing AI. By Sean Grove (OpenAI).
 - [Agentic Coding: The Future of Software Development with Agents](https://www.youtube.com/watch?v=bpWPEhO7RqE) - Hands-on experience running Claude Code: tooling, permissions, and language choices for agentic coding. By Armin Ronacher.
-- [AI Engineer World's Fair 2025: SWE Agents Track](https://www.youtube.com/watch?v=U-fMsbY-kHY) - Keynotes and the software-engineering agents track: coding agents, loops, and the autonomous SDLC. By AI Engineer.
-- [IndyDevDan](https://www.youtube.com/@indydevdan) - Tutorials and patterns for systematically using coding agents (Claude Code, Cursor, Aider) in real engineering work.
 
 ## Case studies and in practice
 - [How Claude Code Is Used in Practice](https://www.anthropic.com/research/claude-code-expertise) - Analysis of roughly 400,000 real sessions: success rates, the human and agent split between planning and execution, and how outcomes vary by expertise. By Anthropic.
-- [How Anthropic Teams Use Claude Code](https://www-cdn.anthropic.com/58284b19e702b49db9302d5b6f135ad8871e7658.pdf) - Team-by-team accounts (data infrastructure, security, product engineering, growth) of how Anthropic staff use Claude Code daily. By Anthropic. (PDF)
 - [AI-Driven Refactoring in Large-Scale Migrations](https://medium.com/qonto-way/ai-driven-refactoring-in-large-scale-migrations-strategies-and-techniques-fcdb9b5116c6) - Building an Aider-based agent to migrate roughly one million lines of Ember.js to React, with throughput rising from about 50 to sometimes over 1,000 lines per engineer per day. By Stefano Amorelli (Qonto).
 - [WhatsCode: Large-Scale GenAI Deployment at WhatsApp](https://arxiv.org/abs/2512.05314) - 25 months of agentic coding at WhatsApp: over 3,000 accepted code changes and privacy-verification coverage rising from 15 to 53 percent. Mao et al. (Meta).
-- [Shipping at Inference Speed](https://steipete.me/posts/2025/shipping-at-inference-speed) - A workflow shipping code the author largely does not read: model choice, context limits, and running three to eight parallel projects. By Peter Steinberger.
 - [A Grounded Take on Agentic Coding for Production](https://iximiuz.com/en/posts/grounded-take-on-agentic-coding/) - Generating over 50,000 lines of mostly AI-written code in a month: task decomposition, domain knowledge, and verification through integration tests. By Ivan Velichko.
 - [Agentic Coding: Things That Didn't Work](https://lucumr.pocoo.org/2025/7/30/things-that-didnt-work/) - An honest post-mortem of abandoned techniques (slash commands, hooks, subagent parallelization) and why. By Armin Ronacher.
-- [Benchmarking Coding Agents on Databricks' Multi-Million Line Codebase](https://www.databricks.com/blog/benchmarking-coding-agents-databricks-multi-million-line-codebase) - An internal benchmark of coding agent models and harnesses against real engineering tasks on a large production codebase, comparing cost against success rate. By Databricks.
 - [Old and New Apps, via Modern Coding Agents](https://terrytao.wordpress.com/2026/07/11/old-and-new-apps-via-modern-coding-agents/) - A mathematician uses a coding agent to port decades-old Java applets to JavaScript, which surfaces bugs in the original code, then builds a new visualization tool he had abandoned years earlier. By Terence Tao.
-- [devopsstart](https://devopsstart.com) - A DevOps learning site written and operated by an autonomous agentic content pipeline, run by this list's maintainer. By Fatih Koc.
 
 ## Communities
 - [Cursor Community Forum](https://forum.cursor.com/) - Official forum for the Cursor coding agent: agent workflows, model comparisons, and rules configuration.
 - [Latent Space Discord](https://www.latent.space/p/community) - AI engineering community with channels for agents, evals, and coding tools, plus a weekly paper club.
-- [Claude Code Builders](https://claude-world.com/community/) - Community for Claude Code users with a Discord, weekly cowork sessions, and monthly tech talks.
 - [Aider Discord](https://discord.com/invite/Y7X7bhMQFV) - Community for the Aider CLI pair-programming agent where users share configurations, model choices, and workflows.
 - [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/) - Subreddit on Claude and Claude Code: agentic coding workflows, configurations, and results.
 - [r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/) - Tool-agnostic subreddit for AI-assisted and agentic coding (Claude Code, Cursor, Aider, and more).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [A Grounded Take on Agentic Coding for Production](https://iximiuz.com/en/posts/grounded-take-on-agentic-coding/) - Generating over 50,000 lines of mostly AI-written code in a month: task decomposition, domain knowledge, and verification through integration tests. By Ivan Velichko.
 - [Agentic Coding: Things That Didn't Work](https://lucumr.pocoo.org/2025/7/30/things-that-didnt-work/) - An honest post-mortem of abandoned techniques (slash commands, hooks, subagent parallelization) and why. By Armin Ronacher.
 - [Old and New Apps, via Modern Coding Agents](https://terrytao.wordpress.com/2026/07/11/old-and-new-apps-via-modern-coding-agents/) - A mathematician uses a coding agent to port decades-old Java applets to JavaScript, which surfaces bugs in the original code, then builds a new visualization tool he had abandoned years earlier. By Terence Tao.
+- [devopsstart](https://devopsstart.com) - A DevOps learning site written and operated by an autonomous agentic content pipeline, run by this list's maintainer. By Fatih Koc.
 
 ## Communities
 - [Cursor Community Forum](https://forum.cursor.com/) - Official forum for the Cursor coding agent: agent workflows, model comparisons, and rules configuration.

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ This list is human-fronted, and partly maintained by the discipline it documents
 (the [weekly-curator skill](.claude/skills/weekly-curator/SKILL.md)) drafts a pull request: it scans for
 newly-published, in-scope resources and checks the existing links for rot. The maintainer reviews and merges
 every change by hand, so nothing lands without a human. The agent does the legwork; the judgment stays human.
+This list is deliberately bounded: each section holds only its best entries (a per-section cap, enforced in CI), so a new resource earns its place by beating one already here.


### PR DESCRIPTION
## Make the list lean: per-section caps, one-time cull, add-or-swap curator

This converts the list from an unbounded, add-only collection into a bounded best-N list. Each section now has a maximum, enforced in CI, and the README is culled to those caps in the same PR so the new check lands green. The list goes from 89 entries to 65 (24 cuts). The weekly-curator routine is rewritten so a full section grows only by displacing its weakest entry, not by appending. This leans on the plan's "what's real vs theater" spine over raw comprehensiveness: a curated best-N is the stronger Show HN pitch for a solo maintainer.

### Decision: devopsstart kept (Case studies cap raised to 7)

The original draft flagged `devopsstart` (the maintainer's own project) as a proposed cut from Case studies on leanness and humility grounds. Decision: keep it. The Case studies cap is raised from 6 to 7 so devopsstart stays without displacing any third-party case study. That entry earns its slot on merit (a live site written and operated by an autonomous agentic content pipeline). Case studies therefore goes 10 to 7, and the overall list settles at 65.

### Cuts (24)

**Start here (8 to 7):**
- No Vibes Allowed: the on-ramp already covers the loop step via "Designing agentic loops"; the talk stays one click away in Videos and talks. Keeps the on-ramp to a tight seven.

**Coding agents and tools (14 to 8):**
- Sourcegraph Amp: far lower adoption than the kept agents; overlaps Cursor and Cline as an IDE-plus-terminal agent.
- Factory (Droids): enterprise platform, thin individual adoption; Factory was already represented via the Factory 2.0 essay.
- Google Jules: newer and less proven; Devin already holds the autonomous long-horizon slot.
- Terminal-Bench: a benchmark, not an agent or tool; benchmarks sit nearer Foundations, where SWE-bench already lives.
- CodeRabbit: narrow (AI code review), not a general coding agent.
- Spec Kit: spec-driven development is already represented (the Spec-Driven course, Sean Grove's talk).

**Books (7 to 6):**
- Generative AI for Software Development: a shorter report and the lowest-profile title here next to Osmani, Kim/Yegge, and Taulli.

**Courses (6 to 5):**
- Anthropic Academy: a catalog landing page; specific Anthropic courses (Claude Code in Action) are already listed.

**Podcasts (6 to 5):**
- The Agentic Review Podcast: a vendor-run podcast (marketing-adjacent) and the narrowest in scope.

**Blogs and newsletters (9 to 6):**
- Factory Blog: company blog; Factory is over-represented.
- Cognition Blog: company blog; Cognition is already represented via Devin.
- Armin Ronacher (lucumr): his strongest agentic writing is already surfaced via his essay and case study; the blog index is the redundant mention.

**Essays and writing (11 to 6):**
- Claude Code Best Practices: already surfaced in Start here.
- 12-Factor Agents: already surfaced in Start here.
- Designing agentic loops: already surfaced in Start here.
- Factory 2.0: From Coding Agents to Software Factories: vendor vision piece; Factory is over-represented.
- Better Models: Worse Tools: the second Ronacher essay and narrower; his honest-failure angle is already covered by "Things That Didn't Work" in Case studies.

**Videos and talks (7 to 5):**
- AI Engineer World's Fair 2025 SWE Agents Track: a track playlist, not a single talk.
- IndyDevDan: a channel pointer, not a specific talk.

**Case studies and in practice (10 to 7):**
- How Anthropic Teams Use Claude Code: vendor self-report overlapping the flagship 400,000-session study; a PDF.
- Shipping at Inference Speed: more anecdote than rigorous case; Steinberger stays on the list via his blog.
- Benchmarking Coding Agents on Databricks' Multi-Million Line Codebase: an eval writeup more than a production case study; the benchmark theme is already in Foundations.
- (devopsstart kept; see Decision above.)

**Communities (6 to 5):**
- Claude Code Builders: a smaller third-party community; the Cursor forum, Latent Space, the Aider Discord, and the two subreddits already cover the community surface.

### Mechanism

- `.github/section-caps.txt`: the single source of truth for caps (ceiling 65). Start here 7, Foundations 5, Coding agents and tools 8, Books 6, Courses 5, Podcasts 5, Blogs and newsletters 6, Essays and writing 6, Videos and talks 5, Case studies and in practice 7, Communities 5.
- `.github/check-caps.py`: fails if any capped section exceeds its cap. Wired as a new `caps` CI job in `.github/workflows/ci.yml`.
- `.github/allowed-duplicate-links.txt`: trimmed from 8 to 4 lines. Three Essays cuts and the Start-here cut removed the second copy of four URLs, so those allowlist lines were stale.
- `.claude/skills/weekly-curator/SKILL.md`: rewritten from add-only to add-or-swap. A full section is displaced (one swap per section per run, head-to-head rationale, human merges); the skill reads the caps file at runtime, no hardcoded numbers.
- CONTRIBUTING.md and README.md: document the bounded best-N policy.

### Verification (run locally against this branch)

- `check-caps.py`: OK, every capped section at or under its cap, 65 entries across the eleven capped sections.
- awesome-lint (with the intentional Start here duplicates filtered): passed.
- style guard (no em or en dashes, no emojis in README and CONTRIBUTING): clean.
- Link check (lychee) runs in this PR's CI.

Drafted by the wiki-autodev-execute routine (queue task `awesome-lean-caps`).
