### PR TITLE
curate: weekly review 2026-07-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [Aider](https://github.com/Aider-AI/aider) - Open-source terminal pair-programming agent that edits code in a local Git repository using an LLM of choice.
 - [Cline](https://github.com/cline/cline) - Open-source autonomous coding agent available as an IDE extension, CLI, and SDK.
 - [Devin](https://devin.ai/) - Autonomous AI software engineer for long-horizon tasks like migrations, bug fixes, and PRs. By Cognition.
-- [OpenHands](https://github.com/All-Hands-AI/OpenHands) - Open-source, self-hostable platform for running coding agents and automations.
+- [OpenHands](https://github.com/OpenHands/OpenHands) - Open-source, self-hostable platform for running coding agents and automations.
 - [Model Context Protocol](https://modelcontextprotocol.io/) - Open standard for connecting coding agents to external tools, data, and workflows. By Anthropic.
 
 ## Books
@@ -101,7 +101,7 @@ A small set of the seminal work underneath agentic coding. Background, not the w
 - [A Grounded Take on Agentic Coding for Production](https://iximiuz.com/en/posts/grounded-take-on-agentic-coding/) - Generating over 50,000 lines of mostly AI-written code in a month: task decomposition, domain knowledge, and verification through integration tests. By Ivan Velichko.
 - [Agentic Coding: Things That Didn't Work](https://lucumr.pocoo.org/2025/7/30/things-that-didnt-work/) - An honest post-mortem of abandoned techniques (slash commands, hooks, subagent parallelization) and why. By Armin Ronacher.
 - [Old and New Apps, via Modern Coding Agents](https://terrytao.wordpress.com/2026/07/11/old-and-new-apps-via-modern-coding-agents/) - A mathematician uses a coding agent to port decades-old Java applets to JavaScript, which surfaces bugs in the original code, then builds a new visualization tool he had abandoned years earlier. By Terence Tao.
-- [devopsstart](https://devopsstart.com) - A DevOps learning site written and operated by an autonomous agentic content pipeline, run by this list's maintainer. By Fatih Koc.
+- [How Anthropic Runs Large-Scale Code Migrations with Claude Code](https://claude.com/blog/ai-code-migration) - A rulebook, dependency map, and verification-loop methodology for porting production codebases, including Bun's million-line Zig-to-Rust migration. By Anthropic.
 
 ## Communities
 - [Cursor Community Forum](https://forum.cursor.com/) - Official forum for the Cursor coding agent: agent workflows, model comparisons, and rules configuration.


### PR DESCRIPTION
## A note on this run's verification method

This session's outbound network policy blocked essentially all direct HTTP fetches (WebFetch and curl both got policy 403s on nearly every host, including example.com). I verified GitHub-hosted links through the GitHub API (which was reachable) and used web search as corroborating evidence for everything else, but I could not do a live per-URL fetch/status check across the full README this run. CI's lychee link check will do the authoritative pass once this PR is up. Treat the "dead or broken links" section below as based on API/search evidence, not a full crawl.

## Additions
None outside a swap (see below); the sections a new candidate would land in that are under cap didn't turn up anything that cleared the bar this week.

## Swaps
**Case studies and in practice** (at cap, 7/7):
+ Add: [How Anthropic Runs Large-Scale Code Migrations with Claude Code](https://claude.com/blog/ai-code-migration) - published July 24, 2026. A primary-source, reproducible methodology (rulebook, dependency map, verification loops) for large migrations, anchored by Bun's million-line Zig-to-Rust port in under two weeks.
- Cut: `devopsstart` (devopsstart.com) - the maintainer's own general-purpose DevOps content site, linked with no specific engineering case study attached. Weakest entry in the section by the "what's real vs theater" bar: most marketing-adjacent (self-link), least evergreen (a rolling content site rather than a documented case study).

Head-to-head: the new entry is a concrete, primary-source account of an engineering process with verifiable outcomes; the outgoing entry is a plug for a separate site with no case-study substance of its own. Happy to leave devopsstart.com in if you'd rather keep it and pick a different displacement target, or skip the swap entirely.

Runner-up considered and left out: Boris Cherny's "Steps of AI Adoption" maturity-ladder framework (Anthropic, July 16, 2026) originated as an X/social post rather than a standalone written piece, so it didn't clear the "real, substantive" bar this week.

Also considered and deliberately left out:
- xAI's Grok Build (github.com/xai-org/grok-build), newly open-sourced July 15, 2026 - passed on it because it was open-sourced shortly after reports that the tool had been uploading excessive portions of users' repos to Google Cloud, and I couldn't verify from here whether that's been resolved.
- Pi (badlogic/pi-mono), a minimal coding-agent harness by Mario Zechner - reportedly acquired by Armin Ronacher's Earendil, and I could no longer find the repo under its original name/org via the GitHub API. Left out until the current canonical URL is confirmed rather than guessing.

## Dead or broken links found
None confirmed dead. One link has moved (see maintenance fix below); GitHub API checks against every other github.com entry in the list (Aider, cline, PacktPublishing book, humanlayer/12-factor-agents, humanlayer/advanced-context-engineering..., openai/codex) came back active and unarchived.

## Stale or out-of-scope entries to review
- **OpenHands link fixed in this PR**: `github.com/All-Hands-AI/OpenHands` no longer resolves via the GitHub API (`All-Hands-AI/OpenHands` search returns "does not exist"); the project's org renamed to `OpenHands`, and `github.com/OpenHands/OpenHands` is the same project, active, 82k+ stars. Updated the existing entry's URL in place (not a swap, no cap impact).


---
_Generated by [Claude Code](https://claude.ai/code/session_01B1yZiU4SnRCWbWEXTNE4R6)_