### PR TITLE
Automate monthly releases from a changelog

### DIFF
--- a/.claude/skills/weekly-curator/SKILL.md
+++ b/.claude/skills/weekly-curator/SKILL.md
@@ -48,20 +48,31 @@ full section is not an option. When a section is full, you displace, you do not 
      take the single strongest and name the runner-up in the PR body without adding it.
    - Every swap needs a one-line head-to-head rationale: new beats old because X; old is superseded by or
      weaker than Y.
-6. Create a branch `curate/YYYY-MM-DD`, apply the changes keeping formatting and ordering consistent,
+6. Record every change in `CHANGELOG.md` under `## Unreleased`, in the same commit as the README edit. Use
+   only the subsections you need, in this order: `### Added` (bare adds), `### Swapped` (displacements),
+   `### Removed` (dead or out-of-scope entries you cut), `### Fixed` (corrected or moved URLs). One bullet
+   per change, each ending with its section name in parentheses:
+   - Added or Fixed: `- [Title](url) - one-line reason or what changed. (Section)`
+   - Swapped: `- [New](url) replaces Old Title (old bare URL in backticks) - head-to-head reason. (Section)`
+   - Removed: `- Old Title (bare URL in backticks) - why it was cut. (Section)`
+   Leave dead and displaced URLs unlinked, in backticks, so nothing in the repo points at rot. Never create,
+   rename, or date a version heading: `.github/workflows/release.yml` turns the Unreleased block into a dated
+   release on the first of each month, and that block is the only part of the file you touch.
+7. Create a branch `curate/YYYY-MM-DD`, apply the changes keeping formatting and ordering consistent,
    commit, push the branch, and open a pull request titled `curate: weekly review YYYY-MM-DD`. Structure the
    PR body in four parts:
    - Additions (to under-cap sections), each with a one-line rationale.
    - Swaps, each as `+ add / - cut` with the head-to-head rationale.
    - Dead or broken links found, with entry and status.
    - Stale or out-of-scope entries to review, with entry and reason.
-7. Before opening the PR, run `python3 .github/check-caps.py README.md .github/section-caps.txt` and confirm
+8. Before opening the PR, run `python3 .github/check-caps.py README.md .github/section-caps.txt` and confirm
    it passes. Do NOT merge and do NOT push to main. If nothing clears the bar and there are no maintenance
    findings, open no pull request. If there are only maintenance findings, open a pull request with just
    those.
 
 ## Rules
 - You draft, the human ships. Never merge, never push to main.
+- In `CHANGELOG.md`, only ever touch the `## Unreleased` block. Releases are cut by workflow, never by you.
 - The list is bounded. A full section is displaced, never appended to. One swap per section per run.
 - Small and high-signal beats large and noisy.
 - No em-dashes or en-dashes (use commas or parentheses); no emojis.

--- a/.github/cut-release.py
+++ b/.github/cut-release.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Cut a release section out of CHANGELOG.md.
+
+Moves everything under `## Unreleased` into a dated `## <version> (<date>)` section, leaves a fresh empty
+Unreleased in its place, and writes the release notes for `gh release create`.
+
+Exit codes:
+  0  a release section was cut (or would be, under --dry-run)
+  1  the changelog or arguments are malformed
+  2  Unreleased holds no entries, so there is nothing to release
+"""
+
+import argparse
+import re
+import sys
+
+UNRELEASED = "## Unreleased"
+VERSION_RE = re.compile(r"^\d{4}\.\d{2}$")
+FOOTER = "The full list: <https://awesomeagenticengineering.com>"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", default="CHANGELOG.md")
+    parser.add_argument("--version", required=True, help="calendar version, YYYY.MM")
+    parser.add_argument("--date", required=True, help="release date, YYYY-MM-DD")
+    parser.add_argument("--notes-out", help="write the release notes here")
+    parser.add_argument("--dry-run", action="store_true", help="do not rewrite the changelog")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if not VERSION_RE.match(args.version):
+        sys.exit(f"error: version {args.version!r} is not YYYY.MM")
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
+        sys.exit(f"error: date {args.date!r} is not YYYY-MM-DD")
+
+    with open(args.changelog, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    heading = next((i for i, line in enumerate(lines) if line.strip() == UNRELEASED), None)
+    if heading is None:
+        sys.exit(f"error: no {UNRELEASED!r} heading in {args.changelog}")
+    if any(line.strip() == f"## {args.version}" or line.startswith(f"## {args.version} (")
+           for line in lines):
+        sys.exit(f"error: {args.changelog} already has a {args.version} section")
+
+    following = next((i for i in range(heading + 1, len(lines)) if lines[i].startswith("## ")),
+                     len(lines))
+    body = "\n".join(lines[heading + 1:following]).strip("\n")
+    if not any(line.startswith("- ") for line in body.split("\n")):
+        print(f"nothing to release: {UNRELEASED} has no entries")
+        return 2
+
+    notes = f"{body}\n\n{FOOTER}\n"
+    if args.notes_out:
+        with open(args.notes_out, "w", encoding="utf-8") as handle:
+            handle.write(notes)
+
+    head = "\n".join(lines[:heading]).rstrip("\n")
+    tail = "\n".join(lines[following:]).strip("\n")
+    parts = [head, "", UNRELEASED, "", f"## {args.version} ({args.date})", "", body]
+    if tail:
+        parts += ["", tail]
+    rewritten = "\n".join(parts).rstrip("\n") + "\n"
+
+    if args.dry_run:
+        print(f"dry run: would cut {args.version} ({args.date}) with notes:\n\n{notes}")
+        return 0
+
+    with open(args.changelog, "w", encoding="utf-8") as handle:
+        handle.write(rewritten)
+    print(f"cut {args.version} ({args.date})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
       - name: No em/en dashes, no emojis
         run: |
           status=0
-          if grep -RnP '[\x{2013}\x{2014}]' README.md CONTRIBUTING.md; then
+          if grep -RnP '[\x{2013}\x{2014}]' README.md CONTRIBUTING.md CHANGELOG.md; then
             echo "Found em or en dashes. Use commas or parentheses instead."
             status=1
           fi
-          if grep -RnP '[\x{1F000}-\x{1FAFF}\x{2600}-\x{27BF}\x{FE0F}\x{2190}-\x{21FF}]' README.md CONTRIBUTING.md; then
+          if grep -RnP '[\x{1F000}-\x{1FAFF}\x{2600}-\x{27BF}\x{FE0F}\x{2190}-\x{21FF}]' README.md CONTRIBUTING.md CHANGELOG.md; then
             echo "Found emojis or decorative symbols. Remove them."
             status=1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Monthly release
+
+# Cuts a calendar release (YYYY.MM) from the Unreleased block in CHANGELOG.md on the first of each month,
+# closing out the month that just ended. No human step: everything in the notes already passed review when
+# its curation pull request was merged. Quiet months publish nothing.
+
+on:
+  schedule:
+    - cron: '0 7 1 * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (YYYY.MM). Defaults to the month that just ended.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Print the notes and probe write access without publishing.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: cut monthly release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version, date, and title
+        id: meta
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+            date="$(date -u +%Y-%m-%d)"
+          else
+            # Running on the first: the month being closed out ended yesterday.
+            last_day="$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m-%d)"
+            version="$(date -u -d "$last_day" +%Y.%m)"
+            date="$last_day"
+          fi
+          title="$(date -u -d "${version//./-}-01" +'%B %Y')"
+          {
+            echo "version=$version"
+            echo "date=$date"
+            echo "title=$title"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved $version ($date), titled $title"
+
+      - name: Skip if the tag already exists
+        id: tag
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $VERSION already exists, nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Roll the changelog
+        id: cut
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          DATE: ${{ steps.meta.outputs.date }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -uo pipefail
+          flags=""
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            flags="--dry-run"
+          fi
+          python3 .github/cut-release.py \
+            --changelog CHANGELOG.md \
+            --version "$VERSION" \
+            --date "$DATE" \
+            --notes-out "$RUNNER_TEMP/notes.md" \
+            $flags
+          code=$?
+          if [ "$code" -eq 2 ]; then
+            echo "empty=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          exit "$code"
+
+      - name: Summarize the notes
+        if: steps.cut.outputs.empty != 'true' && steps.tag.outputs.exists == 'false'
+        run: cat "$RUNNER_TEMP/notes.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Probe write access
+        if: inputs.dry_run
+        run: |
+          set -euo pipefail
+          git push origin "HEAD:refs/tags/release-write-probe"
+          git push origin ":refs/tags/release-write-probe"
+          echo "contents: write confirmed, probe tag removed"
+
+      - name: Commit the rollover and publish the release
+        if: ${{ !inputs.dry_run && steps.tag.outputs.exists == 'false' && steps.cut.outputs.empty != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          TITLE: ${{ steps.meta.outputs.title }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "release: $VERSION"
+          git push origin HEAD:main
+          gh release create "$VERSION" \
+            --title "$TITLE" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
+            --target main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+What changed in the list. Each weekly curation run records its additions, swaps, removals, and link fixes
+under Unreleased, and a workflow cuts a release from that block on the first of each month. This changelog
+starts on 2026-07-26; earlier history is in the git log.
+
+## Unreleased
+
+### Swapped
+- [How Anthropic Runs Large-Scale Code Migrations with Claude Code](https://claude.com/blog/ai-code-migration) replaces devopsstart (`https://devopsstart.com`) - A production migration methodology (rulebook, dependency map, verification loop) outweighs the maintainer's own site in a section at cap. (Case studies and in practice)
+
+### Fixed
+- [OpenHands](https://github.com/OpenHands/OpenHands) - Repository URL updated after the All-Hands-AI organization was renamed. (Coding agents and tools)

--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ This list is human-fronted, and partly maintained by the discipline it documents
 newly-published, in-scope resources and checks the existing links for rot. The maintainer reviews and merges
 every change by hand, so nothing lands without a human. The agent does the legwork; the judgment stays human.
 This list is deliberately bounded: each section holds only its best entries (a per-section cap, enforced in CI), so a new resource earns its place by beating one already here.
+Every merged change is recorded in the [changelog](CHANGELOG.md), and a release is cut from it on the first of
+each month. Stars do not send notifications on GitHub, so to follow what gets added, use Watch, Custom,
+Releases, or subscribe to the
+[releases feed](https://github.com/fatihkc/awesome-agentic-engineering/releases.atom).


### PR DESCRIPTION
## Why

Merged curation runs are currently invisible unless someone watches the diff. Worth knowing up front: **stars send no notifications on GitHub** ("stars have no effect on notifications or the activity feed", per GitHub's own docs), so no release can reach stargazers directly. What a release does buy: a visible freshness signal on the repo, a permanent "what's new" artifact, and the one mechanism that *can* notify people (Watch, Custom, Releases, or the `releases.atom` feed), which the README now points at.

## What

Fully automated, no recurring manual step:

- **`CHANGELOG.md`** with a permanent `## Unreleased` block. Seeded with the 2026-07-26 curation run; earlier history stays in the git log.
- **`.claude/skills/weekly-curator/SKILL.md`**: new step 6. The curator records every add, swap, removal, and URL fix under `## Unreleased` in the same commit as the README edit, with `### Added` / `### Swapped` / `### Removed` / `### Fixed` mirroring the four parts of its PR body. It is told never to create, rename, or date a version heading. Dead and displaced URLs stay unlinked in backticks so nothing in the repo points at rot.
- **`.github/workflows/release.yml`**: cron on the 1st at 07:00 UTC, closing out the month that just ended. Rolls `Unreleased` into `## YYYY.MM (date)`, commits, tags, and publishes the release with that block as the notes.
- **`.github/cut-release.py`**: the parse/rewrite/notes step, so it is testable outside CI.
- **`.github/workflows/ci.yml`**: style guard (no em/en dashes, no emoji) now covers `CHANGELOG.md`. Deliberately **not** added to the lychee link check, since removed entries are dead links by definition and would fail CI forever.

## Guardrails

- **Empty `Unreleased` publishes nothing**, so quiet months stay silent.
- **Existing tag is a no-op**, so the job is safe to re-run.
- The human gate is untouched: curation PRs still get reviewed and merged by hand. Auto-publishing is safe here because every line in the notes already passed that review at merge time; the workflow adds no judgment.
- Failed scheduled runs email the repo owner, so a silent break is not a failure mode.

## Verification

Ran locally against this branch:

| Check | Result |
|---|---|
| `awesome-lint` | pass |
| `npm test` (site) | 6/6 pass |
| `npm run build` | pass, 61 entries across 11 sections |
| `check-caps.py` | pass, all sections at or under cap |
| Style guard (dashes, emoji) | clean across README, CONTRIBUTING, CHANGELOG |
| Both workflow YAMLs | parse |
| `cut-release.py` cases | normal cut, dry run (no write), empty Unreleased (exit 2), duplicate version (exit 1), bad version format (exit 1) |

## One thing to do after merge

The repo's default Actions token is read-only, so the job elevates with `permissions: contents: write`. I could not verify from the docs that elevation beats a read-only repo default, so the workflow ships with a `dry_run` dispatch mode that prints the notes and pushes then deletes a throwaway tag to prove write access. Worth one dispatch after merge to confirm before the 1st: **Actions, Monthly release, Run workflow, dry_run: true**. If it 403s, flip Settings, Actions, Workflow permissions to read/write. The first real release (`2026.07`) then cuts itself on 2026-08-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)